### PR TITLE
パスワード確認フォーム の追加

### DIFF
--- a/app/assets/stylesheets/modules/_signup.scss
+++ b/app/assets/stylesheets/modules/_signup.scss
@@ -43,6 +43,9 @@
         }
         &__password {
           @include m-top15;
+          &--confirmation {
+            @include m-top15;
+          }
         }
         &__identification {
           @include m-top15;

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,8 +6,6 @@
     .form-user-wrapper
       .form-user
         = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-          = render "devise/shared/error_messages", resource: resource
-
           .form-user__nickname
             = f.label :ニックネーム
             %span.form-required
@@ -27,9 +25,16 @@
             %span.form-required
               必須
             %br/
-            = f.password_field :password, autocomplete: "new-password", placeholder: "６文字以上の半角英数字", class: "input-default"
+            = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上の半角英数字", class: "input-default"
           %p
             ＊英字と数字の両方を含めて設定してください。
+
+          .form-user__password--confirmation
+            = f.label :パスワード再入力
+            %span.form-required
+              必須
+            %br/
+            = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上の半角英数字", class: "input-default"
 
           .form-user__identification
             本人確認


### PR DESCRIPTION
## What
ユーザー新規登録画面で、パスワード確認フォーム の追加実装

## Why
サーバーサイド実装において、ビジネスルールで必須項目のため